### PR TITLE
Update AlertRobot to support different sources

### DIFF
--- a/DropBear/Alerts/Alert+Presets.swift
+++ b/DropBear/Alerts/Alert+Presets.swift
@@ -5,6 +5,9 @@ public enum ContactAlertButton: String, AlertButton {
 
 extension Alert {
     public static var contactsPermission: Alert<ContactAlertButton> {
-        return .init(text: "would like to access your contacts")
+        return .init(
+            source: { _ in Springboard.application },
+            containingText: "would like to access your contacts"
+        )
     }
 }

--- a/DropBear/Alerts/Alert+RunningRobot.swift
+++ b/DropBear/Alerts/Alert+RunningRobot.swift
@@ -23,7 +23,7 @@ extension RunningRobot {
         file: StaticString = #file, line: UInt = #line
         ) -> NextRobot<AlertRobot<Alert<T>>>
     {
-        let dialog = Springboard.application.alerts.firstMatch
+        let dialog = alert.source(app).alerts.firstMatch
         let actualDialog: XCUIElement
         if required {
             actualDialog = dialog.assert(.exists, .contains(alert.text), file: file, line: line)

--- a/DropBear/Alerts/Alert.swift
+++ b/DropBear/Alerts/Alert.swift
@@ -1,7 +1,15 @@
 import XCTest
 
 public struct Alert<Button: AlertButton> {
+    public typealias ApplicationSource = (_ current: XCUIApplication) -> XCUIApplication
+
+    public let source: ApplicationSource
     public let text: String
+
+    public init(source: @escaping ApplicationSource, containingText text: String) {
+        self.source = source
+        self.text = text
+    }
 }
 
 public protocol AlertType {

--- a/DropBear/XCTest/XCUIApplication+Element.swift
+++ b/DropBear/XCTest/XCUIApplication+Element.swift
@@ -14,6 +14,6 @@ extension XCUIApplication {
 
         let root = descendants(matching: first)
         let container = hierarchy.dropFirst().reduce(root) { $0.descendants(matching: $1) }
-        return container.element(matching: .any, identifier: identifier).firstMatch
+        return container.element(matching: .any, identifier: identifier)
     }
 }


### PR DESCRIPTION
Previously only springboard alerts (permissions for example) were supported. This adds support for in app alerts (or any other `XCUIApplication` needed)