### PR TITLE
Updates

### DIFF
--- a/DropBear.xcodeproj/project.pbxproj
+++ b/DropBear.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		32E109BC238C97C4002F9286 /* Robot+Tap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E109BB238C97C4002F9286 /* Robot+Tap.swift */; };
 		32E109BE238C9928002F9286 /* Robot+Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E109BD238C9928002F9286 /* Robot+Text.swift */; };
 		32E109C2238C9BE6002F9286 /* AlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E109C1238C9BE6002F9286 /* AlertButton.swift */; };
+		32F965F3240743D800353112 /* RunningRobot+Modal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F965F2240743D800353112 /* RunningRobot+Modal.swift */; };
 		B5AE80AB2285DE6E0098CF95 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AE80AA2285DE6E0098CF95 /* AppDelegate.swift */; };
 		B5AE80B22285DE6E0098CF95 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5AE80B12285DE6E0098CF95 /* Assets.xcassets */; };
 		B5AE80B52285DE6E0098CF95 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5AE80B32285DE6E0098CF95 /* LaunchScreen.storyboard */; };
@@ -172,6 +173,7 @@
 		32E109BB238C97C4002F9286 /* Robot+Tap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Robot+Tap.swift"; sourceTree = "<group>"; };
 		32E109BD238C9928002F9286 /* Robot+Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Robot+Text.swift"; sourceTree = "<group>"; };
 		32E109C1238C9BE6002F9286 /* AlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertButton.swift; sourceTree = "<group>"; };
+		32F965F2240743D800353112 /* RunningRobot+Modal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RunningRobot+Modal.swift"; sourceTree = "<group>"; };
 		B5AE80A82285DE6E0098CF95 /* DropBearApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DropBearApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5AE80AA2285DE6E0098CF95 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B5AE80B12285DE6E0098CF95 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				32701CD22391AF49004283B5 /* RunningRobot+Root.swift */,
 				32701CD42391AF70004283B5 /* RunningRobot+NavigationController.swift */,
 				32701CD62391D38F004283B5 /* RunningRobot+TabBarController.swift */,
+				32F965F2240743D800353112 /* RunningRobot+Modal.swift */,
 			);
 			path = RunningRobot;
 			sourceTree = "<group>";
@@ -868,6 +871,7 @@
 				32B7BE2C22CECEE900931646 /* CellContainerRobot.swift in Sources */,
 				32701CD32391AF49004283B5 /* RunningRobot+Root.swift in Sources */,
 				32B7BE3022CECEE900931646 /* ElementAssertion+Contains.swift in Sources */,
+				32F965F3240743D800353112 /* RunningRobot+Modal.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DropBear/Robot/Robot+Launch.swift
+++ b/DropBear/Robot/Robot+Launch.swift
@@ -2,14 +2,14 @@ import XCTest
 
 extension Robot {
     /// Launch the application for testing passing the provided configuration
-    public static func launch<T: Codable>(using configuration: T) -> RunningRobot<None, T, Self, Root> {
+    public static func launch<T: Codable>(using configuration: T) -> RunningRobot<T, Base, None, Self, Root> {
         let app = XCUIApplication()
         app.launchForTesting(with: configuration)
         return .init(configuration: configuration, current: .init(app: app), previous: .init(app: app))
     }
 
     /// Launch the application for testing
-    public static func launch() -> RunningRobot<None, NoConfiguration, Self, Root> {
+    public static func launch() -> RunningRobot<NoConfiguration, Base, None, Self, Root> {
         let app = XCUIApplication()
         app.launchForTesting()
         return .init(configuration: .init(), current: .init(app: app), previous: .init(app: app))

--- a/DropBear/Robot/Robot+Launch.swift
+++ b/DropBear/Robot/Robot+Launch.swift
@@ -2,17 +2,17 @@ import XCTest
 
 extension Robot {
     /// Launch the application for testing passing the provided configuration
-    public static func launch<T: Codable>(using configuration: T) -> RunningRobot<None, Self, Root> {
+    public static func launch<T: Codable>(using configuration: T) -> RunningRobot<None, T, Self, Root> {
         let app = XCUIApplication()
         app.launchForTesting(with: configuration)
-        return .init(current: .init(app: app), previous: .init(app: app))
+        return .init(configuration: configuration, current: .init(app: app), previous: .init(app: app))
     }
 
     /// Launch the application for testing
-    public static func launch() -> RunningRobot<None, Self, Root> {
+    public static func launch() -> RunningRobot<None, NoConfiguration, Self, Root> {
         let app = XCUIApplication()
         app.launchForTesting()
-        return .init(current: .init(app: app), previous: .init(app: app))
+        return .init(configuration: .init(), current: .init(app: app), previous: .init(app: app))
     }
 }
 

--- a/DropBear/RunningRobot/Alerts/RunningRobot+Alerts.swift
+++ b/DropBear/RunningRobot/Alerts/RunningRobot+Alerts.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 extension RunningRobot {
-    public typealias ActiveAlertRobot<T: AlertButton> = AlertRobot<Alert<T>, RunningRobot<Context, Configuration, Current, Previous>>
+    public typealias ActiveAlertRobot<T: AlertButton> = AlertRobot<Alert<T>, RunningRobot<Configuration, Tree, Context, Current, Previous>>
 
     public func alert<T: AlertButton>(_ alert: Alert<T>, required: Bool = true, file: StaticString = #file, line: UInt = #line) -> ActiveAlertRobot<T> {
         let dialog = alert.source(app).alerts.firstMatch

--- a/DropBear/RunningRobot/Alerts/RunningRobot+Alerts.swift
+++ b/DropBear/RunningRobot/Alerts/RunningRobot+Alerts.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 extension RunningRobot {
-    public typealias ActiveAlertRobot<T: AlertButton> = AlertRobot<Alert<T>, RunningRobot<Context, Current, Previous>>
+    public typealias ActiveAlertRobot<T: AlertButton> = AlertRobot<Alert<T>, RunningRobot<Context, Configuration, Current, Previous>>
 
     public func alert<T: AlertButton>(_ alert: Alert<T>, required: Bool = true, file: StaticString = #file, line: UInt = #line) -> ActiveAlertRobot<T> {
         let dialog = alert.source(app).alerts.firstMatch

--- a/DropBear/RunningRobot/RunningRobot+Modal.swift
+++ b/DropBear/RunningRobot/RunningRobot+Modal.swift
@@ -1,0 +1,24 @@
+public protocol ModalRobotTree: RobotTree {
+    associatedtype Tree: RobotTree
+    associatedtype Context: RobotContext
+    associatedtype Current: Robot
+    associatedtype Previous: Robot
+}
+
+public enum Modal<Tree: RobotTree, Context: RobotContext, Current: Robot, Previous: Robot>: ModalRobotTree { }
+
+extension RunningRobot {
+    public typealias ModalRobot<Next: Robot> = RunningRobot<Configuration, Modal<Tree, Context, Current, Previous>, None, Next, Root>
+
+    public enum ModalAction { case modal }
+
+    public func nextRobot<T: Robot>(_: T.Type = T.self, action: ModalAction) -> ModalRobot<T> {
+        return .init(configuration: configuration, current: .init(app: app), previous: .init(app: app))
+    }
+}
+
+extension RunningRobot where Tree: ModalRobotTree {
+    public func dismissModal(file: StaticString = #file, line: UInt = #line) -> RunningRobot<Configuration, Tree.Tree, Tree.Context, Tree.Current, Tree.Previous> {
+        return .init(configuration: configuration, current: .init(app: app), previous: .init(app: app))
+    }
+}

--- a/DropBear/RunningRobot/RunningRobot+NavigationController.swift
+++ b/DropBear/RunningRobot/RunningRobot+NavigationController.swift
@@ -3,7 +3,7 @@ import XCTest
 public enum NavigationController: RobotContext { }
 
 extension RunningRobot {
-    public typealias NavigationRobot<Next: Robot> = RunningRobot<NavigationController, Configuration, Next, RunningRobot<Context, Configuration, Current, Previous>>
+    public typealias NavigationRobot<Next: Robot> = RunningRobot<Configuration, Tree, NavigationController, Next, RunningRobot<Configuration, Tree, Context, Current, Previous>>
 
     public enum NavigationAction { case push }
 

--- a/DropBear/RunningRobot/RunningRobot+NavigationController.swift
+++ b/DropBear/RunningRobot/RunningRobot+NavigationController.swift
@@ -3,12 +3,12 @@ import XCTest
 public enum NavigationController: RobotContext { }
 
 extension RunningRobot {
-    public typealias NavigationRobot<Next: Robot> = RunningRobot<NavigationController, Next, RunningRobot<Context, Current, Previous>>
+    public typealias NavigationRobot<Next: Robot> = RunningRobot<NavigationController, Configuration, Next, RunningRobot<Context, Configuration, Current, Previous>>
 
     public enum NavigationAction { case push }
 
     public func nextRobot<T: Robot>(_: T.Type = T.self, action: NavigationAction) -> NavigationRobot<T> {
-        return .init(current: .init(app: app), previous: self)
+        return .init(configuration: configuration, current: .init(app: app), previous: self)
     }
 }
 

--- a/DropBear/RunningRobot/RunningRobot+Root.swift
+++ b/DropBear/RunningRobot/RunningRobot+Root.swift
@@ -1,11 +1,11 @@
 public enum None: RobotContext { }
 
 extension RunningRobot {
-    public typealias RootRobot<Current: Robot> = RunningRobot<None, Current, Root>
+    public typealias RootRobot<Current: Robot> = RunningRobot<None, Configuration, Current, Root>
     
     public enum RootAction { case root }
 
     public func nextRobot<T: Robot>(_: T.Type = T.self, action: RootAction) -> RootRobot<T> {
-        return RootRobot(current: .init(app: app), previous: .init(app: app))
+        return RootRobot(configuration: configuration, current: .init(app: app), previous: .init(app: app))
     }
 }

--- a/DropBear/RunningRobot/RunningRobot+Root.swift
+++ b/DropBear/RunningRobot/RunningRobot+Root.swift
@@ -1,7 +1,7 @@
 public enum None: RobotContext { }
 
 extension RunningRobot {
-    public typealias RootRobot<Current: Robot> = RunningRobot<None, Configuration, Current, Root>
+    public typealias RootRobot<Current: Robot> = RunningRobot<Configuration, Tree, None, Current, Root>
     
     public enum RootAction { case root }
 

--- a/DropBear/RunningRobot/RunningRobot+TabBarController.swift
+++ b/DropBear/RunningRobot/RunningRobot+TabBarController.swift
@@ -5,7 +5,7 @@ public protocol TabBarRobot: Robot { }
 public enum TabBarItem: RobotContext { }
 
 extension RunningRobot where Current: TabBarRobot {
-    public typealias TabItemRobot<Next: Robot> = RunningRobot<TabBarItem, Configuration, Next, RunningRobot<Context, Configuration, Current, Previous>>
+    public typealias TabItemRobot<Next: Robot> = RunningRobot<Configuration, Tree, TabBarItem, Next, RunningRobot<Configuration, Tree, Context, Current, Previous>>
 
     public enum TabItemAction { case tab(Int) }
 

--- a/DropBear/RunningRobot/RunningRobot+TabBarController.swift
+++ b/DropBear/RunningRobot/RunningRobot+TabBarController.swift
@@ -5,7 +5,7 @@ public protocol TabBarRobot: Robot { }
 public enum TabBarItem: RobotContext { }
 
 extension RunningRobot where Current: TabBarRobot {
-    public typealias TabItemRobot<Next: Robot> = RunningRobot<TabBarItem, Next, RunningRobot<Context, Current, Previous>>
+    public typealias TabItemRobot<Next: Robot> = RunningRobot<TabBarItem, Configuration, Next, RunningRobot<Context, Configuration, Current, Previous>>
 
     public enum TabItemAction { case tab(Int) }
 
@@ -24,7 +24,7 @@ extension RunningRobot where Current: TabBarRobot {
 
         app.tabBars.buttons.element(boundBy: index).tap()
 
-        return .init(current: .init(app: app), previous: self)
+        return .init(configuration: configuration, current: .init(app: app), previous: self)
     }
 }
 

--- a/DropBear/RunningRobot/RunningRobot.swift
+++ b/DropBear/RunningRobot/RunningRobot.swift
@@ -2,11 +2,13 @@ import XCTest
 
 public protocol RobotContext { }
 
-public struct NoConfiguration {
-    init() { }
-}
+public struct NoConfiguration { }
 
-public class RunningRobot<Context: RobotContext, Configuration, Current: Robot, Previous: Robot>: Robot {
+public protocol RobotTree { }
+
+public enum Base: RobotTree { }
+
+public class RunningRobot<Configuration, Tree: RobotTree, Context: RobotContext, Current: Robot, Previous: Robot>: Robot {
     public typealias Element = Current.Element
 
     public var app: XCUIApplication { return current.app }
@@ -15,7 +17,7 @@ public class RunningRobot<Context: RobotContext, Configuration, Current: Robot, 
     public let current: Current
     public let previous: Previous
 
-    public required init(configuration: Configuration, current: Current, previous: Previous) {
+    required init(configuration: Configuration, current: Current, previous: Previous) {
         self.configuration = configuration
         self.current = current
         self.previous = previous

--- a/DropBear/RunningRobot/RunningRobot.swift
+++ b/DropBear/RunningRobot/RunningRobot.swift
@@ -2,15 +2,21 @@ import XCTest
 
 public protocol RobotContext { }
 
-public class RunningRobot<Context: RobotContext, Current: Robot, Previous: Robot>: Robot {
+public struct NoConfiguration {
+    init() { }
+}
+
+public class RunningRobot<Context: RobotContext, Configuration, Current: Robot, Previous: Robot>: Robot {
     public typealias Element = Current.Element
 
     public var app: XCUIApplication { return current.app }
 
+    public let configuration: Configuration
     public let current: Current
     public let previous: Previous
 
-    public required init(current: Current, previous: Previous) {
+    public required init(configuration: Configuration, current: Current, previous: Previous) {
+        self.configuration = configuration
         self.current = current
         self.previous = previous
     }

--- a/DropBear/Traits/CellContainerRobot.swift
+++ b/DropBear/Traits/CellContainerRobot.swift
@@ -3,9 +3,19 @@ import XCTest
 public protocol CellContainerRobot: Robot { }
 
 extension RunningRobot where Current: CellContainerRobot {
-    public func nextRobot<T: Robot>(_: T.Type = T.self, forCell index: Int, file: StaticString = #file, line: UInt = #line) -> NavigationRobot<T> {
+    public func nextRobot<T: Robot>(_: T.Type = T.self, forCell index: Int, action: RootAction, file: StaticString = #file, line: UInt = #line) -> RootRobot<T> {
         _ = current.tap(cell: index, file: file, line: line)
-        return nextRobot(action: .push)
+        return nextRobot(action: action)
+    }
+
+    public func nextRobot<T: Robot>(_: T.Type = T.self, forCell index: Int, action: NavigationAction, file: StaticString = #file, line: UInt = #line) -> NavigationRobot<T> {
+        _ = current.tap(cell: index, file: file, line: line)
+        return nextRobot(action: action)
+    }
+
+    public func nextRobot<T: Robot>(_: T.Type = T.self, forCell index: Int, action: ModalAction, file: StaticString = #file, line: UInt = #line) -> ModalRobot<T> {
+        _ = current.tap(cell: index, file: file, line: line)
+        return nextRobot(action: action)
     }
 }
 


### PR DESCRIPTION
- Attaches the configuration a test was launched with (if any) to the RunningRobots so code can be written that might need access to it without the need to pass it in.

- Encodes `Tree` info into `RunningRobot`s to deal with modal navigation (a fork from the base where _any_ subsequent robot might want to return to the base)