### PR TITLE
Updates for Xcode 12.5 and Swift 5.4

### DIFF
--- a/DropBear.xcodeproj/xcshareddata/xcschemes/DropBearApp.xcscheme
+++ b/DropBear.xcodeproj/xcshareddata/xcschemes/DropBearApp.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5AE80A72285DE6E0098CF95"
+               BuildableName = "DropBearApp.app"
+               BlueprintName = "DropBearApp"
+               ReferencedContainer = "container:DropBear.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5AE80BA2285DE6F0098CF95"
+               BuildableName = "DropBearAppUITests.xctest"
+               BlueprintName = "DropBearAppUITests"
+               ReferencedContainer = "container:DropBear.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5AE80A72285DE6E0098CF95"
+            BuildableName = "DropBearApp.app"
+            BlueprintName = "DropBearApp"
+            ReferencedContainer = "container:DropBear.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5AE80A72285DE6E0098CF95"
+            BuildableName = "DropBearApp.app"
+            BlueprintName = "DropBearApp"
+            ReferencedContainer = "container:DropBear.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DropBear/XCTest/XCUIElement+Optional.swift
+++ b/DropBear/XCTest/XCUIElement+Optional.swift
@@ -13,15 +13,15 @@ extension XCUIElement {
     }
 }
 
-/// Internal `XCUIElement` subclass that is returned when an optional element is requested but not found.
+/// Internal `XCUIApplication` subclass that is returned when an optional element is requested but not found.
 /// This prevents optional paths in test from failing when functions such as `tap()` are called on missing elements.
-class MissingXCUIElement: XCUIElement {
+class MissingXCUIElement: XCUIApplication {
     override var exists: Bool { return false }
     override var isHittable: Bool { return false }
     override func waitForExistence(timeout: TimeInterval) -> Bool { return false }
     override var debugDescription: String { return String(describing: MissingXCUIElement.self) }
 
-    init(element: XCUIElement) { }
+    init(element: XCUIElement) { super.init() }
 
     override func typeText(_ text: String) { }
     override func tap() { }

--- a/DropBearGen/Package.resolved
+++ b/DropBearGen/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
-          "version": "0.50200.0"
+          "revision": "2fff9fc25cdc059379b6bd309377cfab45d8520c",
+          "version": "0.50400.0"
         }
       }
     ]

--- a/DropBearGen/Package.swift
+++ b/DropBearGen/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "DropBearGen",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
         .package(url: "https://github.com/tid-kijyun/Kanna.git", from: "4.0.0")
     ],
     targets: [


### PR DESCRIPTION
* Convert MissingXCUIElement to extend XCUIApplication, now that XCUIElement no longer has available inits.
* Use SwiftSyntax 0.50400.0